### PR TITLE
Create classTestInfoCarburant

### DIFF
--- a/classTestInfoCarburant
+++ b/classTestInfoCarburant
@@ -1,0 +1,60 @@
+package org.isen.carburant.model.data
+
+import com.github.kittinunf.fuel.core.isSuccessful
+import com.github.kittinunf.fuel.core.response
+import com.github.kittinunf.fuel.httpGet
+import org.junit.Before
+import org.junit.Test
+import java.security.cert.X509Certificate
+import javax.net.ssl.HostnameVerifier
+import javax.net.ssl.HttpsURLConnection
+import javax.net.ssl.SSLContext
+import javax.net.ssl.TrustManager
+import javax.net.ssl.X509TrustManager
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+
+class SslConnectionJUnitTest {
+
+    @Before
+    fun prepare() {
+        useInsecureSSL()
+    }
+
+    @Test
+    fun myTest(){
+        val (resquest, response, result)= "https://data.economie.gouv.fr/api/records/1.0/search/?dataset=prix-carburants-fichier-instantane-test-ods-copie&q=&rows=10000&sort=-prix_maj&facet=id&facet=adresse&facet=ville&facet=prix_maj&facet=prix_nom&facet=com_arm_name&facet=epci_name&facet=dep_name&facet=reg_name&facet=services_service&facet=horaires_automate_24_24"
+            .httpGet().response(CarburantInformation.Deserializer())
+
+        assertTrue(response.isSuccessful)
+
+        println(response)
+        println("result : ${result}")
+        val(si: CarburantInformation?, error)= result
+        assertNotNull(si,"error because station list must be not null")
+        assertEquals(10000,si.records.size)
+    }
+
+
+    private fun useInsecureSSL() {
+        // Create a trust manager that does not validate certificate chains
+        val trustAllCerts = arrayOf<TrustManager>(object : X509TrustManager {
+            override fun getAcceptedIssuers(): Array<X509Certificate>? = null
+            override fun checkClientTrusted(chain: Array<X509Certificate>, authType: String) = Unit
+            override fun checkServerTrusted(chain: Array<X509Certificate>, authType: String) = Unit
+        })
+
+        val sc = SSLContext.getInstance("SSL")
+        sc.init(null, trustAllCerts, java.security.SecureRandom())
+        HttpsURLConnection.setDefaultSSLSocketFactory(sc.socketFactory)
+
+        // Create all-trusting host name verifier
+        val allHostsValid = HostnameVerifier { _, _ -> true }
+
+        // Install the all-trusting host verifier
+        HttpsURLConnection.setDefaultHostnameVerifier(allHostsValid)
+    }
+}
+
+


### PR DESCRIPTION
package org.isen.carburant.model.data

import com.github.kittinunf.fuel.core.isSuccessful
import com.github.kittinunf.fuel.core.response
import com.github.kittinunf.fuel.httpGet
import org.junit.Before
import org.junit.Test
import java.security.cert.X509Certificate
import javax.net.ssl.HostnameVerifier
import javax.net.ssl.HttpsURLConnection
import javax.net.ssl.SSLContext
import javax.net.ssl.TrustManager
import javax.net.ssl.X509TrustManager
import kotlin.test.assertEquals
import kotlin.test.assertNotNull
import kotlin.test.assertTrue

class SslConnectionJUnitTest {

    @Before
    fun prepare() {
        useInsecureSSL()
    }

    @Test
    fun myTest(){
        val (resquest, response, result)= "https://data.economie.gouv.fr/api/records/1.0/search/?dataset=prix-carburants-fichier-instantane-test-ods-copie&q=&rows=10000&sort=-prix_maj&facet=id&facet=adresse&facet=ville&facet=prix_maj&facet=prix_nom&facet=com_arm_name&facet=epci_name&facet=dep_name&facet=reg_name&facet=services_service&facet=horaires_automate_24_24"
            .httpGet().response(CarburantInformation.Deserializer())

        assertTrue(response.isSuccessful)

        println(response)
        println("result : ${result}")
        val(si: CarburantInformation?, error)= result
        assertNotNull(si,"error because station list must be not null")
        assertEquals(10000,si.records.size)
    }


    private fun useInsecureSSL() {
        // Create a trust manager that does not validate certificate chains
        val trustAllCerts = arrayOf<TrustManager>(object : X509TrustManager {
            override fun getAcceptedIssuers(): Array<X509Certificate>? = null
            override fun checkClientTrusted(chain: Array<X509Certificate>, authType: String) = Unit
            override fun checkServerTrusted(chain: Array<X509Certificate>, authType: String) = Unit
        })

        val sc = SSLContext.getInstance("SSL")
        sc.init(null, trustAllCerts, java.security.SecureRandom())
        HttpsURLConnection.setDefaultSSLSocketFactory(sc.socketFactory)

        // Create all-trusting host name verifier
        val allHostsValid = HostnameVerifier { _, _ -> true }

        // Install the all-trusting host verifier
        HttpsURLConnection.setDefaultHostnameVerifier(allHostsValid)
    }
}


